### PR TITLE
Fix web search tool calls

### DIFF
--- a/backend/tools/analysis_tools.py
+++ b/backend/tools/analysis_tools.py
@@ -16,7 +16,7 @@ from db_utils import get_db_type_creds
 from defog.llm.utils import chat_async
 from defog.query import async_execute_query_once
 import uuid
-from typing import Callable
+from typing import Any, Callable
 from google import genai
 from google.genai.types import Tool, GenerateContentConfig, GoogleSearch
 from anthropic import AsyncAnthropic
@@ -129,29 +129,52 @@ async def text_to_sql_tool(
 
 async def web_search_tool(
     input: AnswerQuestionInput,
-) -> str:
+) -> dict[str, Any]:
     """
     Given a user question, this tool will visit the top ranked pages on Google and extract information from them.
     It will then concisely answer the question based on the extracted information, and will return the answer as a JSON, with a "reference_sources" key that lists the web pages from which the information was extracted and an "answer" key that contains the concisely answered question.
     It should be used when a question cannot be directly answered by the database, or when additional context can be provided to the user by searching the web.
     """
+    LOGGER.info(f"Web search tool called with question: {input.question}")
+    
     client = genai.Client(api_key=os.environ.get("GEMINI_API_KEY"))
     google_search_tool = Tool(
         google_search = GoogleSearch()
     )
-    response = await client.aio.models.generate_content(
-        model="gemini-2.0-flash",
-        config=GenerateContentConfig(
-            tools=[google_search_tool],
-            response_modalities=["TEXT"],
-        ),
-        contents=input.question + "\nNote: you must **always** use the google search tool to answer questions - no exceptions.",
-    )
-    sources = [{"source": chunk.web.title, "url": chunk.web.uri} for chunk in response.candidates[0].grounding_metadata.grounding_chunks]
-    return {
-        "answer": response.text,
-        "reference_sources": sources
-    }
+    
+    try:
+        response = await client.aio.models.generate_content(
+            model="gemini-2.0-flash",
+            config=GenerateContentConfig(
+                tools=[google_search_tool],
+                response_modalities=["TEXT"],
+            ),
+            contents=input.question + "\nNote: you must **always** use the google search tool to answer questions - no exceptions.",
+        )
+        
+        LOGGER.info(f"Received response from Gemini API: {response}")
+        
+        # Handle the case where grounding_chunks might be None
+        sources = []
+        if response.candidates:
+            for candidate in response.candidates:
+                if candidate.grounding_metadata and candidate.grounding_metadata.grounding_chunks:
+                    for chunk in candidate.grounding_metadata.grounding_chunks:
+                        sources.append({
+                            "source": chunk.web.title,
+                            "url": chunk.web.uri
+                        })
+        return {
+            "answer": response.text,
+            "reference_sources": sources
+        }
+    except Exception as e:
+        LOGGER.error(f"Error calling Gemini API: {e}")
+        return {
+            "answer": "Error calling Gemini API",
+            "error": str(e),
+            "reference_sources": []
+        }
 
 
 async def pdf_citations_tool(

--- a/backend/tools/tool_routes.py
+++ b/backend/tools/tool_routes.py
@@ -82,10 +82,14 @@ async def web_search_route(request: WebSearchRequest):
     summary of the search results.
     """
     try:
+        LOGGER.info(f"Web search route called with question: {request.question}")
+        
         search_input = AnswerQuestionInput(
             question=request.question,
         )
         search_result = await web_search_tool(search_input)
+        
+        LOGGER.info(f"Web search completed successfully")
         
         # Return a structured response
         return {
@@ -93,6 +97,7 @@ async def web_search_route(request: WebSearchRequest):
             "search_result": search_result
         }
     except Exception as e:
+        LOGGER.error(f"Error in web_search_route: {str(e)}", exc_info=True)
         # Return error information
         return {
             "question": request.question,


### PR DESCRIPTION
Fix web search tool calls as I was getting errors like:

```
2025-03-03 10:24:28 Error: Error executing tool `web_search_tool`: 'NoneType' object is not iterable
```

We use the recommended code structure based on the [search grounding docs](https://ai.google.dev/gemini-api/docs/migrate#search_grounding). Have tested generating a few new reports via the frontend end-to-end and the error goes away.

